### PR TITLE
Force re-authentication before responding to chat message

### DIFF
--- a/main.go
+++ b/main.go
@@ -315,6 +315,12 @@ func main() {
 					var recipient = chatId
 					lowerMessage := strings.ToLower(content)
 
+					err = pegassClient.Authenticate()
+					if err != nil {
+						log.Errorf("failed to authenticate to pegass: '%s'", err.Error())
+						return
+					}
+
 					if strings.HasPrefix(lowerMessage, "!psr") {
 						botService.SendActivitySummary(recipient, SAMU, 3)
 					} else if strings.HasPrefix(lowerMessage, "!bspp") {


### PR DESCRIPTION
In the future, I should look into re-using the current authentication ticket and check if it works before going through the authentication process from scratch.