### PR TITLE
Stop following redirects in Pegass session check

### DIFF
--- a/pegass-client.go
+++ b/pegass-client.go
@@ -284,7 +284,14 @@ func (p *PegassClient) AuthenticateIfNecessary() error {
 }
 
 func (p *PegassClient) shouldReAuthenticate() bool {
-	response, err := p.httpClient.Get("https://pegass.croix-rouge.fr/crf/rest/gestiondesdroits")
+	noRedirectHttpClient := &http.Client{
+		Jar: p.cookieJar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	response, err := noRedirectHttpClient.Get("https://pegass.croix-rouge.fr/crf/rest/gestiondesdroits")
 	if err != nil {
 		log.Warnf("reauthenticate check request failed: '%s'", err.Error())
 		return true


### PR DESCRIPTION
Context
-------

When performing a request to Pegass, the application checks whether the session is still active.

This check consists in calling a simple Pegass API and checking the http response.

Problem
-------

Even when the session is expired, the API check returns an HTTP 200 status code.

This is because Pegass automatically redirects the caller to the authentication provider.

Fix
---

Disable following redirects in HTTP calls when checking session status.
